### PR TITLE
externpro 26.01-42-g46119d2

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 1.16.0.4 tag",
-  "tag": "xpv1.16.0.4"
+  "message": "xpro version 1.16.0.5 tag",
+  "tag": "xpv1.16.0.5"
 }

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01-42-g46119d2`

## Changes

- Updated `.devcontainer` to externpro `26.01-42-g46119d2`
- Previous HEAD: `10fee788c7ac45bed71deb6eac5a0605ad37a8eb`
- New HEAD: `46119d2840eb811260885cb200137d895fea7f3b`
- Updated `.github/release-tag.json` (tag: `xpv1.16.0.5`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv1.16.0.5\`
- Updated caller workflows to match templates

### Workflow Update Report

- ✓ xprelease.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
