### PR TITLE
externpro 26.01.1

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 1.16.0.5 tag",
-  "tag": "xpv1.16.0.5"
+  "message": "xpro version 1.16.0.6 tag",
+  "tag": "xpv1.16.0.6"
 }

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,15 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.1
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.1
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.1
     secrets: inherit
     with: {}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.1
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.1
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1`

## Changes

- Updated `.devcontainer` to externpro `26.01.1`
- Previous HEAD: `46119d2840eb811260885cb200137d895fea7f3b`
- New HEAD: `a2e89c849bc0cee02e7a5813c98f2c147509f7cc`
- Updated `.github/release-tag.json` (tag: `xpv1.16.0.6`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv1.16.0.6\`
- Updated caller workflows to match templates

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
